### PR TITLE
int8_mode backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@
 
 **NOTE: Fastertransformer backend is currently undergoing restructuring. Build instructions are only tested with Triton container versions <= `23.04`**. 
 
+**It's a stable branch here, for more you can see the `dev-llama-backend` branch.**
+
 # 1. FasterTransformer Backend
 
 **The triton faster transformer backend works as an interface to call FasterTransformer in triton.**

--- a/all_models/llama/fastertransformer/config.pbtxt
+++ b/all_models/llama/fastertransformer/config.pbtxt
@@ -29,10 +29,6 @@ backend: "fastertransformer"
 default_model_filename: "llama"
 max_batch_size: 1024
 
-model_transaction_policy {
-  decoupled: True
-}
-
 input [
   {
     name: "input_ids"

--- a/docs/llama_guide.md
+++ b/docs/llama_guide.md
@@ -195,3 +195,8 @@ I0628 02:59:06.219577 11650 http_server.cc:184] Started Metrics Service at 0.0.0
 ```
 
 That means the program was launched successfully.
+
+# Update
++ offer `int8_mode` support in `libfastertransformer.cc` to make sure the compiler can find matching function.
++ remove `decoupled mode: true` in [config.pbtxt](../all_models/llama/fastertransformer/config.pbtxt#L31)
+  the `decoupled mode` seems to be a bug, not fixed so far. If you have any solution to this, welcome to contribute.

--- a/src/libfastertransformer.cc
+++ b/src/libfastertransformer.cc
@@ -333,13 +333,14 @@ std::shared_ptr<AbstractTransformerModel> ModelState::ModelFactory(
     }
   } else if (model_type == "Llama") {
     if (data_type == "fp16") {
-      ft_model = std::make_shared<LlamaTritonModel<half>>(tp, pp, custom_ar, model_dir);
+      const int         int8_mode  = param_get_int(param, "int8_mode");
+      ft_model = std::make_shared<LlamaTritonModel<half>>(tp, pp, custom_ar, model_dir, int8_mode);
 #ifdef ENABLE_BF16
     } else if (data_type == "bf16") {
-      ft_model = std::make_shared<LlamaTritonModel<__nv_bfloat16>>(tp, pp, custom_ar, model_dir);
+      ft_model = std::make_shared<LlamaTritonModel<__nv_bfloat16>>(tp, pp, custom_ar, model_dir, int8_mode);
 #endif
     } else if (data_type == "fp32") {
-      ft_model = std::make_shared<LlamaTritonModel<float>>(tp, pp, custom_ar, model_dir);
+      ft_model = std::make_shared<LlamaTritonModel<float>>(tp, pp, custom_ar, model_dir, int8_mode);
     } else {
       LOG_MESSAGE(TRITONSERVER_LOG_ERROR, dt_message.c_str());
     }


### PR DESCRIPTION
Hello, sir.

According to the discussions in community, here are some bug to be fixed:

#### 1. int8_mode support

The backend script cannot support int8_mode so far and need to change the source code manually. See [here](https://github.com/NVIDIA/FasterTransformer/issues/506#issuecomment-1621719726) for more info.

Several parameters were added to fix this:

```cpp
const int         int8_mode  = param_get_int(param, "int8_mode");
ft_model = std::make_shared<LlamaTritonModel<half>>(tp, pp, custom_ar, model_dir, int8_mode);
ft_model = std::make_shared<LlamaTritonModel<__nv_bfloat16>>(tp, pp, custom_ar, model_dir, int8_mode);
ft_model = std::make_shared<LlamaTritonModel<float>>(tp, pp, custom_ar, model_dir, int8_mode);
```

#### 2. decoupled mode

There are some problems for decoupled mode support, and I still failed to figure out what was the reason.

But when I deleted several lines in `config.pbtxt`, it worked. For more detail you can see the changed files.

Maybe we can discuss the second problem if you have spare time, or deleting these lines maybe a temporary solution.