### PR TITLE
fix the int8_mode and decoupled mode backend support

### DIFF
--- a/all_models/llama/fastertransformer/config.pbtxt
+++ b/all_models/llama/fastertransformer/config.pbtxt
@@ -29,6 +29,10 @@ backend: "fastertransformer"
 default_model_filename: "llama"
 max_batch_size: 1024
 
+model_transaction_policy {
+  decoupled: True
+}
+
 input [
   {
     name: "input_ids"

--- a/all_models/llama/fastertransformer/config.pbtxt
+++ b/all_models/llama/fastertransformer/config.pbtxt
@@ -29,10 +29,6 @@ backend: "fastertransformer"
 default_model_filename: "llama"
 max_batch_size: 1024
 
-model_transaction_policy {
-  decoupled: True
-}
-
 input [
   {
     name: "input_ids"

--- a/docs/llama_guide.md
+++ b/docs/llama_guide.md
@@ -5,7 +5,8 @@ We have deployed LLaMa on triton inference server with faster transformer backen
 + Ubuntu 20.04
 + docker: 24.0.2
 + cmake
-+ python
++ python: 3.10.6
++ pip: 23.1.2
 
 Hardware:
 + RTX 3090 (24G VMEM) * 2
@@ -26,12 +27,14 @@ We will expand our work in `llama_deploy` directory.
 ## 1. build docker image
 To reproduce all further steps that would be easier to run everything into Docker container. So it's necessary to build a triton docker image for next steps.
 
+The reason why we choose the image tag:23.04 is that this may support the decoupled mode. See this [issue](https://github.com/triton-inference-server/server/issues/6002#issuecomment-1617106369) for more info.
+
 ```bash
 git clone https://github.com/void-main/fastertransformer_backend.git
 
 cd fastertransformer_backend
 
-sudo docker build --rm --build-arg TRITON_VERSION=22.12 -t triton_ft_backend:22.12 -f docker/Dockerfile .
+sudo docker build --rm --build-arg TRITON_VERSION=23.04 -t triton_ft_backend:23.04 -f docker/Dockerfile .
 ```
 
 The build process may take more than five minutes, depending on your hardware.
@@ -41,7 +44,7 @@ When finished, launch the container:
 ```bash
 cd ../
 
-sudo docker run -it --rm --gpus=all --net=host --shm-size=4G  -v $(pwd):/ft_workspace -p8888:8888 -p8000:8000 -p8001:8001 -p8002:8002 triton_ft_backend:22.12 bash 
+sudo docker run -it --rm --gpus=all --net=host --shm-size=4G  -v $(pwd):/ft_workspace -p8888:8888 -p8000:8000 -p8001:8001 -p8002:8002 triton_ft_backend:23.04 bash 
 ```
 
 We have mapped the `llama_deploy` directory to `/ft_workspace` inside the container.
@@ -198,5 +201,4 @@ That means the program was launched successfully.
 
 # Update
 + offer `int8_mode` support in `libfastertransformer.cc` to make sure the compiler can find matching function.
-+ remove `decoupled mode: true` in [config.pbtxt](../all_models/llama/fastertransformer/config.pbtxt#L31)
-  the `decoupled mode` seems to be a bug, not fixed so far. If you have any solution to this, welcome to contribute.
++ fix the `decoupled mode` support, you may get access to decoupled mode with a higher version of tritonserver base image! (23.04 tested)

--- a/docs/llama_guide.md
+++ b/docs/llama_guide.md
@@ -195,3 +195,8 @@ I0628 02:59:06.219577 11650 http_server.cc:184] Started Metrics Service at 0.0.0
 ```
 
 That means the program was launched successfully.
+
+# Update
++ offer `int8_mode` support in `libfastertransformer.cc` to make sure the compiler can find matching function.
++ remove `decoupled mode: true` in [config.pbtxt](../all_models/llama/fastertransformer/config.pbtxt#L31)
+  the `decoupled mode` seems to be a bug, not fixed so far. If you have any solution to this, welcome to contribute.

--- a/src/libfastertransformer.cc
+++ b/src/libfastertransformer.cc
@@ -333,13 +333,14 @@ std::shared_ptr<AbstractTransformerModel> ModelState::ModelFactory(
     }
   } else if (model_type == "Llama") {
     if (data_type == "fp16") {
-      ft_model = std::make_shared<LlamaTritonModel<half>>(tp, pp, custom_ar, model_dir);
+      const int         int8_mode  = param_get_int(param, "int8_mode");
+      ft_model = std::make_shared<LlamaTritonModel<half>>(tp, pp, custom_ar, model_dir, int8_mode);
 #ifdef ENABLE_BF16
     } else if (data_type == "bf16") {
-      ft_model = std::make_shared<LlamaTritonModel<__nv_bfloat16>>(tp, pp, custom_ar, model_dir);
+      ft_model = std::make_shared<LlamaTritonModel<__nv_bfloat16>>(tp, pp, custom_ar, model_dir, int8_mode);
 #endif
     } else if (data_type == "fp32") {
-      ft_model = std::make_shared<LlamaTritonModel<float>>(tp, pp, custom_ar, model_dir);
+      ft_model = std::make_shared<LlamaTritonModel<float>>(tp, pp, custom_ar, model_dir, int8_mode);
     } else {
       LOG_MESSAGE(TRITONSERVER_LOG_ERROR, dt_message.c_str());
     }


### PR DESCRIPTION
Hello, sir.

According to the discussion in community, there are two problems to be fixed. The detail:

1. add int8_mode parameters in `libfastertransformer.cc`. It hasn't been added to the functions, and caused error when building the library:
   ```
   error: no matching function for call to LlamaTritonModel<__nv_bfloat16>::LlamaTritonModel(const int&, const int&, const int&, const std::__cxx11::basic_string&)
   ```
   And the followers may add the `int8_mode` parameter manually to make it work. It bothered. 
  
   The param was added into the `libfastertransformer.cc` to void the trouble.
2. support **decoupled mode**

   I have mentioned my solution in the [issue: LLaMa support](https://github.com/NVIDIA/FasterTransformer/issues/506#issuecomment-1623467297) and was discussed. I have found the solution, see this [issue](https://github.com/triton-inference-server/server/issues/6002#issuecomment-1617106369).

   I tried to upgrade the docker base image (tritonserver) version to 23.04 to test if it worked, I also tested version **23.05** before, but failed when building the docker image, so I choose the version **23.04**,  and it seemed to work fine. 

   In this case, there is no need to delete the `model_transaction_policy` lines in `config.pbtxt`.

   The deploying information in [llama_guide](https://github.com/SamuraiBUPT/ft_backend/blob/dev-llama-backend/docs/llama_guide.md) were updated to help fellows.