### PR TITLE
Update libfastertransformer.cc

### DIFF
--- a/src/libfastertransformer.cc
+++ b/src/libfastertransformer.cc
@@ -332,8 +332,8 @@ std::shared_ptr<AbstractTransformerModel> ModelState::ModelFactory(
 #endif
     }
   } else if (model_type == "Llama") {
-    if (data_type == "fp16") {
       const int         int8_mode  = param_get_int(param, "int8_mode");
+    if (data_type == "fp16") {
       ft_model = std::make_shared<LlamaTritonModel<half>>(tp, pp, custom_ar, model_dir, int8_mode);
 #ifdef ENABLE_BF16
     } else if (data_type == "bf16") {


### PR DESCRIPTION
when i follow the llame_guide.md to build this lib ,this error occur

```bash
/workspace/build/fastertransformer_backend/src/libfastertransformer.cc: In member function 'std::shared_ptr<AbstractTransformerModel> triton::backend::fastertransformer_backend::ModelState::ModelFactory(triton::common::TritonJson::Value&, const string&)':
/workspace/build/fastertransformer_backend/src/libfastertransformer.cc:340:98: error: 'int8_mode' was not declared in this scope
  340 |       ft_model = std::make_shared<LlamaTritonModel<__nv_bfloat16>>(tp, pp, custom_ar, model_dir, int8_mode);
      |                                                                                                  ^~~~~~~~~
[100%] Linking CXX executable ../../../../../bin/multi_gpu_gpt_interactive_example
[100%] Built target gptneox_example
[100%] Built target multi_gpu_gpt_triton_example
[100%] Built target llama_example
/workspace/build/fastertransformer_backend/src/libfastertransformer.cc:343:90: error: 'int8_mode' was not declared in this scope
  343 |       ft_model = std::make_shared<LlamaTritonModel<float>>(tp, pp, custom_ar, model_dir, int8_mode);
```
i think the variable should fix.  after i move it , the build success